### PR TITLE
Draft proposal for hub permissioning system

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,44 @@
+# Hub Authentication System
+
+[Back to Explainer](../explainer.md)
+
+## Overview
+There are two mechanisms for authentication to a hub:
+ - The hub operator (i.e. the identity owner) authenticates by signing each request with a private key associated with one or more of their [Factors](#factor-authentication).
+ - Other actors sign requests using the key material required to satisfy the control block from the DDO associated with their [DID](#did-authentication).
+
+## Factor Authentication
+
+`/.identity/:id/factors`*
+
+This route represents the enteries for devices and other auth factors an entity associates with to enable them to sign, authenticate, and manipulate resources.
+
+An example entry for a personal laptop:
+
+```json
+{
+  "factor": {
+    "@id": "7e2fg36y3c31",
+    "name": "Home Laptop",
+    "key": "23fge3fwg34f..."
+  },
+  "sig": "g34df2hgjh5..."
+}
+```
+
+A dongle-type factor example:
+
+```json
+{
+  "factor": {
+    "@id": "36y3c317e2fg",
+    "name": "My Yubikey",
+    "key": "fge3f23wg34f..."
+  },
+  "sig": "65dfjkh32g3..."
+}
+```
+
+## DID Authentication
+
+// TODO

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,115 @@
+# Hub Asset Access Control System
+
+[Back to Explainer](../explainer.md)
+
+## Motivation
+Per the hub specification, there is a need for a flexible, expressive, and simple permissioning system to represent authority over files stored by a hub.
+The goal of this proposal is to present an access control system which:
+- Allows permissions to be delegated to DIDs
+- Supports multiple permission levels for differential access
+- Allows indepdendent permissioning of core endpoints and individual extensions
+
+
+## Permission Levels
+Hubs support basic data manipulation operations which follow RESTful design principles as well as extensions which can expose a REST or RPC-style interface. To handle both styles, this proposal recommends the CRUDX permission set:
+- C: Create
+- R: Read
+- U: Update
+- D: Delete
+- X: Execute
+
+The goal is to provide intuitive permission levels for common operations (`CRUD` for RESTful interfaces) as well as flexible permissioning for complex or aberrant operations (`X` for extensions that manage their own access controls or expose an RPC interface).
+
+### CRUDX Specification
+The CRUDX specification string follows the UNIX file system model: each specification is a bit-array of length 5 where each element of the array represents the corresponding permission level and can be set to `1` (allowed), `0` (not allowed). This can be displayed as a 5-character string where each character is either the first letter of the permission level's name (allowed) or a hyphen (not allowed); hyphens can optionally be omitted (e.g. ```C--DX == CDX```. Since the representation is an ordered list, a permission can also be specified as an unsigned, 5-bit integer (e.g. ```C--DX == 25```).
+
+#### Examples
+| Description | String | Integer |
+|-------------|--------|---------|
+| Full Permissions | `CRUDX` | `31` |
+| Null Permissions | `-----` | `0` |
+| Read Only | `-R---` | `2` |
+| Read & Execute | `-R--X` | `18` |
+
+NOTE: this proposal could be confusing because the integer values of each permission level do NOT match the UNIX levels; they are not even ordered from least to most dangerous.
+
+
+## Identifiers (Permission Recipients/Grantees)
+Following the higher-level architecture of Hubs, the permission system uses DIDs as the primary mechanism for identifying recipients.
+It might also support raw cryptographic keys, but a better idea would be to allow embedded DDOs which can represent raw keys for whatever cryptosystems are supported by the DID spec. Below is a json array of valid identifiers:
+
+> TODO: I'm not sure if there's a simple and valid DDO that just exposes a key without addl rigmarole
+
+```json
+[
+  "did:sov:dan.id",
+  { "@context": "https://example.org/did/v1",
+    "owner": [
+      { "type": ["CryptographicKey", "EdDsaPublicKey"],
+        "curve": "ed25519",
+        "publicKeyBase64": "lji9qTtkCydxtez/bt1zdLxVMMbz4SzWvlqgOBmURoM=" } ]
+  }
+]
+```
+
+
+## PermissionSpecification
+Permissions are represented via a series of `PermissionSpecification` objects. A root PermissionSpecification is stored at: `/.well-known/identity/:id/permissions`. See [Inheritance](#Inheritance) for more on
+
+All `PermissionSpecifications` adhere to the following schema:
+
+| Field | Type | Description | Required | Example |
+|-------|------|-------------|----------|---------|
+| identifiers | array\<DID or DDO> \| glob | This field specifies the entities who are granted the permissions specified by this PermissionSpecification object | TRUE     | <pre>[ "did:sov:dan.id",<br>  {"@context": "https://example.org/did/v1",<br>   "owner": [{<br>     "type": ["CryptographicKey", "EdDsaPublicKey"],<br>     "curve": "ed25519",<br>     "publicKeyBase64": "lji9qTtkCydxtez/bt1zdLxVMMbz4SzWvlqgOBmURoM="}]}]</pre> |
+| path | DID-reference \| glob | The `path` field contains an absolute or relative [DID reference](https://docs.google.com/document/d/1Z-9jX4PEWtyRFD5fEyyzEnWK_0ir0no1JJLuRu8O9Gs/edit#heading=h.q2ajgt4zoqlc) that identifies a directory, data asset, or endpoint. Pattern matching is supported per the [Patterns](###Patterns) section | TRUE | `*`, `./stores`, `did:sov:dan.id/collections/photos` |
+| allowed | [CRUDX specification](#CRUDX-specification) | The permissions granted to the identities specified in `identifiers` | FALSE | `CR--X`, `CRUDX`, `19 (CR--X)`, `31 (CRUDX)` |
+| denied | [CRUDX specification](#CRUDX-specification) | The permissions denied to the identities specified in `identifiers`. NOTE: this field and `allowed` can be merged into a single `permissions` field if we choose a model with no inheritance support | FALSE | `CR--X`, `CRUDX`, `19 (CR--X)`, `31 (CRUDX)` |
+
+### Example
+```json
+{
+  "identifiers": [ "did:sov:dan.id" ],
+  "path": "stores/*",
+  "permission": "C----"
+}
+```
+
+## Paths
+Paths are specified as either full DID-references or relative [DID-paths](https://docs.google.com/document/d/1Z-9jX4PEWtyRFD5fEyyzEnWK_0ir0no1JJLuRu8O9Gs/edit#heading=h.8rl8lput6gnv). Relative paths are relative to the location of the `PermissionSpecification` in which they are used.
+
+### Patterns
+There is a clear need to support specifications that apply to a set of resources, rather than a single path (directory) or resource (data asset). To support this behavior we have to choose a solution that balances expressiveness, comprehensibility, and safety.
+
+#### Options
+- Regex: The obvious solution is to employ regular expressions. While regex are extremely powerful, they are also error prone and difficult to audit.
+- Globs: A less powerful solution but safer solution is UNIX-like glob matching, which provides a subset of regex functionality, particularly `?` (single-character wildcards) and `*` (many-character wildcards).
+
+## Inheritance
+I'd like to see a model where a permission spec can be assigned to any object at any level in the URI. e.g.
+- `/.well-known/identity/:id/permissions`
+- `/.well-known/identity/:id/collections/permissions`
+- `/.well-known/identity/:id/collections/photos/permissions`
+- `/.well-known/identity/:id/extensions/business_hours/permissions`
+
+### Benefits
+- `PermissionSpecification` files stay small and easy to edit
+- Allows for easy-to-understand logical scoping (assuming an easy-to-use hub mgmt GUI)
+
+### Problems
+- This does introduce a lot of complexity around how hierarchical permissions are merged
+- The obvious path structure in the examples above would require a reserved keyword (e.g. `permissions`) in the hub path/filename specification, which is undesirable
+
+
+## Content-Type Selection (Tags/Querying)
+It is useful to be able to select resources based on metadata apart from their path. Examples include selecting all resources:
+- created by a certain identity
+- updated at a certain time
+- adhering to a certain schema, or
+- tagged with a certain label
+
+There are several solutions to address this, ranging from a purpose-built `tags` selector to a full query language. The performance and implementation of those solutions all depend heavily on the way resources are stored and indexed, and at time of writing I'm unsure of how to weigh the solutions' marginal utility against those perf/impl costs.
+
+> i.e. OPEN QUESTION: **How queryable will/should hubs be?**
+
+## Addl Notes
+- I think callbacks are (or should be) outside the scope of the permissioning system, so they haven't been mentioned here.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -18,7 +18,7 @@ Hubs support basic data manipulation operations which follow RESTful design prin
 - D: Delete
 - X: Execute
 
-The goal is to provide intuitive permission levels for common operations (`CRUD` for RESTful interfaces) as well as flexible permissioning for complex or aberrant operations (`X` for extensions that manage their own access controls or expose an RPC interface).
+The goal is to provide intuitive permission levels for common operations (`CRUD` for RESTful interfaces) as well as flexible permissioning for complex or aberrant operations (`X` for extensions that manage their own access controls or expose an RPC interface, e.g. via an `action` body parameter).
 
 ### CRUDX Specification
 The CRUDX specification string follows the UNIX file system model: each specification is a bit-array of length 5 where each element of the array represents the corresponding permission level and can be set to `1` (allowed), `0` (not allowed). This can be displayed as a 5-character string where each character is either the first letter of the permission level's name (allowed) or a hyphen (not allowed); hyphens can optionally be omitted (e.g. ```C--DX == CDX```. Since the representation is an ordered list, a permission can also be specified as an unsigned, 5-bit integer (e.g. ```C--DX == 25```).
@@ -34,7 +34,7 @@ The CRUDX specification string follows the UNIX file system model: each specific
 NOTE: this proposal could be confusing because the integer values of each permission level do NOT match the UNIX levels; they are not even ordered from least to most dangerous.
 
 
-## Identifiers (Permission Recipients/Grantees)
+## DID (Permission Recipients/Grantees)
 Following the higher-level architecture of Hubs, the permission system uses DIDs as the primary mechanism for identifying recipients.
 It might also support raw cryptographic keys, but a better idea would be to allow embedded DDOs which can represent raw keys for whatever cryptosystems are supported by the DID spec. Below is a json array of valid identifiers:
 
@@ -58,47 +58,89 @@ Permissions are represented via a series of `PermissionSpecification` objects. A
 
 All `PermissionSpecifications` adhere to the following schema:
 
-| Field | Type | Description | Required | Example |
+| Field | Type | Description | Required | Examples |
 |-------|------|-------------|----------|---------|
-| identifiers | array\<DID or DDO> \| glob | This field specifies the entities who are granted the permissions specified by this PermissionSpecification object | TRUE     | <pre>[ "did:sov:dan.id",<br>  {"@context": "https://example.org/did/v1",<br>   "owner": [{<br>     "type": ["CryptographicKey", "EdDsaPublicKey"],<br>     "curve": "ed25519",<br>     "publicKeyBase64": "lji9qTtkCydxtez/bt1zdLxVMMbz4SzWvlqgOBmURoM="}]}]</pre> |
-| path | DID-reference \| glob | The `path` field contains an absolute or relative [DID reference](https://docs.google.com/document/d/1Z-9jX4PEWtyRFD5fEyyzEnWK_0ir0no1JJLuRu8O9Gs/edit#heading=h.q2ajgt4zoqlc) that identifies a directory, data asset, or endpoint. Pattern matching is supported per the [Patterns](###Patterns) section | TRUE | `*`, `./stores`, `did:sov:dan.id/collections/photos` |
-| allowed | [CRUDX specification](#CRUDX-specification) | The permissions granted to the identities specified in `identifiers` | FALSE | `CR--X`, `CRUDX`, `19 (CR--X)`, `31 (CRUDX)` |
-| denied | [CRUDX specification](#CRUDX-specification) | The permissions denied to the identities specified in `identifiers`. NOTE: this field and `allowed` can be merged into a single `permissions` field if we choose a model with no inheritance support | FALSE | `CR--X`, `CRUDX`, `19 (CR--X)`, `31 (CRUDX)` |
+| did | DID \| DDO \| glob | This field specifies the entity who is granted the permissions specified by this PermissionSpecification object | TRUE     | <pre> "did:sov:dan.id"</pre><pre>  {"@context": "https://example.org/did/v1",<br>   "owner": [{<br>     "type": ["CryptographicKey", "EdDsaPublicKey"],<br>     "curve": "ed25519",<br>     "publicKeyBase64": "lji9qTtkCydxtez/bt1zdLxVMMbz4SzWvlqgOBmURoM="}]}</pre> |
+| path | DID-reference \| glob | The `path` field contains an absolute or relative [DID reference](https://docs.google.com/document/d/1Z-9jX4PEWtyRFD5fEyyzEnWK_0ir0no1JJLuRu8O9Gs/edit#heading=h.q2ajgt4zoqlc) that identifies a path, data asset, or endpoint. Pattern matching is supported per the [Patterns](###Patterns) section | TRUE | `*`, `./stores`, `did:sov:dan.id/collections/photos` |
+| object_filters | object | The `object_filters` field allows for the selection of data assets using the metadata in the control object which wraps each path and asset. This is (currently) a flat key-value mapping with no pattern-matching support. | FALSE | To allow access to objects _created_ by a given identity: <br> <pre> { "author": "did:btcr:123" } </pre> |
+| argument_filters | object | The `argument_filters` field allows for selection of data assets using the properties of the incoming request which initiated the permission validation. | FALSE | To allow access to execution of an extension's `invokeRPC` method: <br> <pre> { "action": "invokeRPC" } </pre> |
+| allow | [CRUDX specification](#CRUDX-specification) | The permissions granted to the identities specified in `identifiers` | TRUE | `CR--X`, `CRUDX`, `19 (CR--X)`, `31 (CRUDX)` |
+| _deny_ | [CRUDX specification](#CRUDX-specification) | The permissions denied to the identities specified in `identifiers`. NOTE: this is field is not yet part of the specification and is being reserved for possible future inclusion.  | FALSE | `CR--X`, `CRUDX`, `19 (CR--X)`, `31 (CRUDX)` |
+| ext | object | The `ext` field is reserved for additional fields that are use to configure specific routes or extensions. | FALSE | The `/stores` endpoint supports `min_size` and `max_size` to configure how much storage an identity is permitted to keep in its store: <br> <pre> { "min_size": 1, "max_size": 100 } </pre> |
 
 ### Example
+`GET /.identity/:id_owner_did/permissions?path=collections`
 ```json
-{
-  "identifiers": [ "did:sov:dan.id" ],
-  "path": "stores/*",
-  "permission": "C----"
-}
+[{
+  "did": "did:btcr:123",
+  "path": "hl7.org:fhir/*",
+  "object_filters": {
+    "author": "did:btcr:123"
+  },
+  "argument_filters": {
+    "action": "create"
+  },
+  "allow": "CR---",
+  "ext": {
+    "callbacks": [
+      {
+        "event": "created",
+        "uri": URI,
+        "headers": { "X-MY-DOPE-HEADER": 44 }
+      }
+    ]
+  }
+}, ...]
 ```
 
 ## Paths
-Paths are specified as either full DID-references or relative [DID-paths](https://docs.google.com/document/d/1Z-9jX4PEWtyRFD5fEyyzEnWK_0ir0no1JJLuRu8O9Gs/edit#heading=h.8rl8lput6gnv). Relative paths are relative to the location of the `PermissionSpecification` in which they are used.
+The path is the main unit of granularity for permissions. Each `PermissionSpecification` has a `path` field which supports glob pattern matching, and an optional parent path query parameter can be specified in the the get request to the `/permissions` endpoint.
+
+Paths in the body of a `PermissionSpecification` may be either full DID-references or relative [DID-paths](https://docs.google.com/document/d/1Z-9jX4PEWtyRFD5fEyyzEnWK_0ir0no1JJLuRu8O9Gs/edit#heading=h.8rl8lput6gnv). Relative paths are relative to the location of the `PermissionSpecification` in which they are used, e.g.
+
+`GET /.identity/:id_owner_did/permissions`
+```json
+[{
+  "did": "did:btcr:123",
+  "path": "collections/hl7.org:fhir/*",
+  "allow": "CRU--"
+}]
+```
+
+Paths in the query parameter are always relative to the root of the identity owner's DID are being requested, e.g.
+
+`GET /.identity/:id_owner_did/permissions?path=stores&did=btcr:123`
+```json
+[{
+  "did": "did:btcr:123",
+  "path": "did:btcr:123/*",
+  "allow": "CRUD-"
+}]
+```
+If no path is specified in the query string, the implied path is also the root of the identity owner's DID.
 
 ### Patterns
 There is a clear need to support specifications that apply to a set of resources, rather than a single path (directory) or resource (data asset). To support this behavior we have to choose a solution that balances expressiveness, comprehensibility, and safety.
 
-#### Options
-- Regex: The obvious solution is to employ regular expressions. While regex are extremely powerful, they are also error prone and difficult to audit.
-- Globs: A less powerful solution but safer solution is UNIX-like glob matching, which provides a subset of regex functionality, particularly `?` (single-character wildcards) and `*` (many-character wildcards).
+The naive solution is to employ regular expressions. While regex are extremely powerful, they are also error prone and difficult to audit, so instead we elect to use the less powerful solution, but safer solution: UNIX-like glob matching, which provides a subset of regex functionality, particularly `?` (single-character wildcard) and `*` (many-character wildcard).
 
-## Inheritance
-I'd like to see a model where a permission spec can be assigned to any object at any level in the URI. e.g.
-- `/.well-known/identity/:id/permissions`
-- `/.well-known/identity/:id/collections/permissions`
-- `/.well-known/identity/:id/collections/photos/permissions`
-- `/.well-known/identity/:id/extensions/business_hours/permissions`
+Patterns (currently) may only be used in the `path` field of the `PermissionSpecification` object.
 
-### Benefits
-- `PermissionSpecification` files stay small and easy to edit
-- Allows for easy-to-understand logical scoping (assuming an easy-to-use hub mgmt GUI)
+## Inheritance / Field-level Permissions
+The `deny` field of the `PermissionSpecification` is reserved for future use to implement field-level permissioning, i.e. allowing access to a data asset, but resistrictng access to specific fields. This concept is only sensible in the mode where the hub has access to the data asset itself (where it is not encrypted with a client-side encryption key).
 
-### Problems
-- This does introduce a lot of complexity around how hierarchical permissions are merged
-- The obvious path structure in the examples above would require a reserved keyword (e.g. `permissions`) in the hub path/filename specification, which is undesirable
-
+This example will grant `did:btrc:123` access to read the identity owner's profile document, _with the `github-handle` field omitted_:
+```json
+[{
+  "did": "did:btcr:123",
+  "path": "profile",
+  "allow": "-R---"
+}, {
+  "did": "did:btcr:123",
+  "path": "profile#github-handle",
+  "deny": "-R---"
+}]
+```
 
 ## Content-Type Selection (Tags/Querying)
 It is useful to be able to select resources based on metadata apart from their path. Examples include selecting all resources:
@@ -107,9 +149,44 @@ It is useful to be able to select resources based on metadata apart from their p
 - adhering to a certain schema, or
 - tagged with a certain label
 
-There are several solutions to address this, ranging from a purpose-built `tags` selector to a full query language. The performance and implementation of those solutions all depend heavily on the way resources are stored and indexed, and at time of writing I'm unsure of how to weigh the solutions' marginal utility against those perf/impl costs.
+To achieve this, all data assets are wrapped with a control object that contains a finite set (**TODO: define the set**). These fields are exposed via the `object_filters` field in the `PermissionSpecification` which does not support any pattern matching, only direct comparison.
 
-> i.e. OPEN QUESTION: **How queryable will/should hubs be?**
+This example will grant `did:btcr:123` access to only the assets in the `hl7.org:fhir` collection _that were created by `did:btcr:123`_:
+```json
+[{
+  "did": "did:btcr:123",
+  "path": "hl7.org:fhir/*",
+  "object_filters": {
+    "author": "did:btcr:123"
+  }
+}]
+```
 
-## Addl Notes
-- I think callbacks are (or should be) outside the scope of the permissioning system, so they haven't been mentioned here.
+## Callbacks
+In order for applications to operate with hubs reactively, there is a need to expose a mechanism for requesting notifications from the hub when data assets are created/updated/executed/etc. Since this mechanism would essentially enable autonomous operation of the hub, it must be explicitly permissioned. We leverage the `ext` block to add support for callback permissioning.
+
+### CallbackSpecification
+Callback permissions are represented via a series of `CallbackSpecification` objects, which adhere to the following schema: **WIP!**
+
+| Field | Type | Description | Required | Examples |
+|-------|------|-------------|----------|----------|
+| events | array\<CRUDX operation> | The event field specifies when a callback should be launched. (Should this just be a normal CRUDX value?) | TRUE | `["created", "read", "updated", "deleted", "executed"]` |
+| uri | URI | The uri field specifies who should receive the callback notification. This field and the did field are mutually exclusive. | FALSE | `https://someuri.co/callback_endpoint` |
+| did | DID or DDO | The did field specifies who should received. A hub for the receiving DID will be resolved and that will receive the notification. This field and the URI field are mutually exclusive. | FALSE | `did:btcr:123` |
+| headers | object | The headers field contains any custom headers the receiver wants to be included on outgoing callback notification requests. | FALSE | `{ "Content-Type": "application/Person.json" }` |
+
+```json
+[{
+  "did": "did:btcr:123",
+  "path": "hl7.org:fhir/*",
+  "ext": {
+    "callbacks": [{
+      "events": ["created"],
+      "uri": URI,
+      "headers": {"X-MY-DOPE-HEADER": 44}
+    }]
+  }
+}]
+```
+
+TODO: define the callback request interface.

--- a/explainer.md
+++ b/explainer.md
@@ -126,6 +126,8 @@ The REST API uses [JSON API's specification](http://jsonapi.org/format/) for req
 
 The process of authenticating requests from the primary user or an agent shall follow the FIDO and Web Authentication specifications (as closely as possible). These specifications may require modifications in order to support challenging globally known IDs with provably linked keys.
 
+See the [authentication.md](./docs/authentication.md) explainer for details.
+
 #### GET Requests
 
 The REST routes for fetching and manipulating identity data should follow a common path format that maps 1:1 to the schema of data objects being transacted. Here is an example of how to send a `GET` request for an identity's Schema.org formatted music playlists:

--- a/explainer.md
+++ b/explainer.md
@@ -8,7 +8,7 @@ A single entity may have one or more instances of a Hub, all of which are addres
 
 ## Syncing Data to Multiple Hubs
 
-Hub instances must sync data without requiring master-slave relationships or forcing a single implementation for storage or application logic.  This requires a shared replication protocol for broadcasting and resolving changes. [CouchDB](http://docs.couchdb.org/en/2.0.0/replication/protocol.html), an open source Apache project, will be the data syncing protocol Hubs must implement. It features an eventually consistent, master-master replication protocol that can be decoupled from the default storage layer provided by CouchDB. 
+Hub instances must sync data without requiring master-slave relationships or forcing a single implementation for storage or application logic.  This requires a shared replication protocol for broadcasting and resolving changes. [CouchDB](http://docs.couchdb.org/en/2.0.0/replication/protocol.html), an open source Apache project, will be the data syncing protocol Hubs must implement. It features an eventually consistent, master-master replication protocol that can be decoupled from the default storage layer provided by CouchDB.
 
 ## Well-Known URIs
 
@@ -66,64 +66,7 @@ All Hub data associated with the identity must be portable. Transfer of a hub’
 
 All access and manipulation of identity data is subject to the permissions established by the owning entity. Because the identities are self-sovereign, all data associated with the identity must be portable. Transfer of a identity's contents and settings between environments and hosts should be seamless, without loss of data or operational state, including the permissions that govern access to identity data.
 
-These permissions are segmented into the following paths and ACL object structures:
-
-##### Factors
-
-  `/.identity/:id/permissions/`*`factors`*
-
-This route represents the enteries for devices and other auth factors an entity associates with to enable them to sign, authenticate, and manipulate resources.
-
-An example entry for a personal laptop:
-
-```json
-{
-  "factor": {
-    "@id": "7e2fg36y3c31",
-    "name": "Home Laptop",
-    "key": "23fge3fwg34f..."
-  },
-  "sig": "g34df2hgjh5..."
-}
-```
-
-A dongle-type factor example:
-
-```json
-{
-  "factor": {
-    "@id": "36y3c317e2fg",
-    "name": "My Yubikey",
-    "key": "fge3f23wg34f..."
-  },
-  "sig": "65dfjkh32g3..."
-}
-```
-
-##### Agents
-
-  `/.identity/:id/permissions/`*`agents`*
-
-Agents are other entities the identity's owning entity allows to access and manipulate their data. Agents can be granted a `store` and '/collections' access to entire collections, specific object types, or individual objects under an object type. 
-
-Here is an example of a human owning entity's primary care physician being granted access to the routes that correspond to their FHIR encoded medical data:
-
-```json
-{
-"did": "doctor_john.id",
-  "storeSettings": {
-    "maxSize": "default"
-  },
-  "collectionPermissions": [
-    {
-      "identifiers": ["dan.id", "shifty_mcdanielson.id"],
-      "dataPath": "fhir.org:*",
-      "permission": "rwx---rwx",
-      "callbacks": [ "created", "modified" ]
-    }
-  ]
-}
-```
+See the [permissions.md](./docs/permissions.md) explainer for details.
 
 #### Messages
 
@@ -155,7 +98,7 @@ The data shall be a JSON object and should be limited in size, with the option t
 
 #### Collections
 
-Collections provide a known path for accessing standardized, semantic objects across all hubs, in way that asserts as little opinion as possible. The full scope of an identity's data is accessible via the following path 
+Collections provide a known path for accessing standardized, semantic objects across all hubs, in way that asserts as little opinion as possible. The full scope of an identity's data is accessible via the following path
 
 `/.identity/:id/collections/:context`, wherein the path structure is a 1:1 mirror of the schema context declared in the previous path segment. The names of object types may be cased in various schema ontologies, but hub implementations should always treat these paths as case insensitive. Here are a few examples of actual paths and the type of Schema.org objects they will respond with:
 


### PR DESCRIPTION
This PR includes a plain-english proposal for an access control system for hubs.

Major points:
- recommends CRUDX as the permission level set
- ~removes factors (which AFAICT can be encapsulated with DIDs)~
- considers all paths equivalent for the purpose of access control (i.e. no special treatment for built-in routes) with the exception of /stores, which will use the same verification system, but whose permissions will be hard-coded.
- suggests a inheritance model where a permission specification can be applied to fields inside data objects EDIT: marked for future inclusion
- ~deliberately does not address a callback system because I think that should probably be handled elsewhere~
- ~fails to address querying/tagging/content-types because that raises broader questions that have implications for the entire system which need to be discussed~
  Expands the previous callback system to support URIs, headers and other fields
- introduces an `ext` field for route-specific permissions

Minor points:
- the sub-header markdown links probably don't work